### PR TITLE
Reverse Support

### DIFF
--- a/tool/app/Actions/Runes/TranslateSentence.php
+++ b/tool/app/Actions/Runes/TranslateSentence.php
@@ -8,9 +8,10 @@ use App\Enums\Rune;
 
 class TranslateSentence
 {
-    public static function translate(string $sentence): string
+    public static function translate(string $sentence, bool $reverse = false): string
     {
         $letters = '';
+        $method = $reverse ? 'toReversedLetter' : 'toSingleLetter';
 
         $runes = preg_split('//u', $sentence, -1, PREG_SPLIT_NO_EMPTY);
         foreach ($runes as $rune) {
@@ -22,7 +23,7 @@ class TranslateSentence
             }
 
             $enum = Rune::tryFrom($rune);
-            $letters .= $enum?->toSingleLetter() ?? '[?]';
+            $letters .= $enum?->$method() ?? '[?]';
         }
 
         return $letters;

--- a/tool/app/Commands/TranslateSentence.php
+++ b/tool/app/Commands/TranslateSentence.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Commands;
+
+use App\Actions\Runes\TranslateSentence as TranslateSentenceAction;
+use LaravelZero\Framework\Commands\Command;
+
+class TranslateSentence extends Command
+{
+    protected $signature = 'app:translate-sentence';
+
+    protected $description = 'Translate Sentence';
+
+    public function handle(): int
+    {
+        $sentence = $this->ask('Enter a sentence to translate');
+        $reversed = $this->ask('Reverse the translation? (y/n)', 'n');
+
+        $this->output->write(TranslateSentenceAction::translate($sentence, $reversed === 'y').PHP_EOL);
+
+        return self::SUCCESS;
+    }
+}

--- a/tool/app/Enums/Rune.php
+++ b/tool/app/Enums/Rune.php
@@ -47,6 +47,41 @@ enum Rune: string
         };
     }
 
+    public function toReversedLetter(): string
+    {
+        return match ($this) {
+            self::F => 'EA',
+            self::U => '[IA|IO]',
+            self::TH => 'Y',
+            self::O => 'AE',
+            self::R => 'A',
+            self::C_OR_K => 'D',
+            self::G => 'OE',
+            self::W => '[NG|ING]',
+            self::H => 'L',
+            self::N => 'M',
+            self::I => 'E',
+            self::J => 'B',
+            self::EO => 'T',
+            self::P => '[S|Z]',
+            self::X => 'X',
+            self::S_OR_Z => 'P',
+            self::T => 'EO',
+            self::B => 'J',
+            self::E => 'I',
+            self::M => 'N',
+            self::L => 'H',
+            self::NG_OR_ING => 'W',
+            self::OE => 'G',
+            self::D => '[C|K]',
+            self::A => 'R',
+            self::AE => 'O',
+            self::Y => 'TH',
+            self::IA_OR_IO => 'U',
+            self::EA => 'F',
+        };
+    }
+
     public function toSingleLetter(): string
     {
         return match ($this) {
@@ -114,7 +149,6 @@ enum Rune: string
             self::Y => 103,
             self::IA_OR_IO => 107,
             self::EA => 109,
-            default => \InvalidArgumentException::class
         };
     }
 }

--- a/tool/tests/Unit/LiberPrimusReversedTest.php
+++ b/tool/tests/Unit/LiberPrimusReversedTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Actions\Runes\TranslateSentence;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class LiberPrimusReversedTest extends TestCase
+{
+    #[DataProvider('dataProvider')]
+    public function testSentenceReverseDecoding(string $runes, string $sentence): void
+    {
+        $this->assertSame($sentence, TranslateSentence::translate($runes, true));
+    }
+
+    public static function dataProvider(): array
+    {
+        return [
+            // region 01.jpg
+            '01.jpg - line 1' => [
+                'runes' => 'ᚱ ᛝᚱᚪᛗᚹ ᛄᛁᚻᛖᛁᛡᛁ ᛗᚫᚣᚹ ᛠᚪᚫᚾ',
+                'sentence' => 'A WARN[NG|ING] BELIEUE NOTH[NG|ING] FROM',
+            ],
+            '01.jpg - line 2' => [
+                'runes' => 'ᚣᛖᛈ ᛄᚫᚫᛞᛁᛉᛞᛁᛋᛇ ᛝᛚᚱᛇ ᚦᚫᛡ',
+                'sentence' => 'THI[S|Z] BOO[C|K]EX[C|K]EPT WHAT YOU',
+            ],
+            // endregion
+        ];
+    }
+}


### PR DESCRIPTION
In writing Part 2 of 2014 puzzle - I was testing out reverses of Gematria Primus - which I didn't have support for. 


```
➜  tool git:(reverse) ✗ php cicada app:translate-sentence

 Enter a sentence to translate:
 > ᚱ ᛝᚱᚪᛗᚹ ᛄᛁᚻᛖᛁᛡᛁ ᛗᚫᚣᚹ ᛠᚪᚫᚾ

 Reverse the translation? (y/n) [n]:
 > n

R [NG|ING]RAMW JIHEI[IA|IO]I MAEYW EAAAEN
➜  tool git:(reverse) php cicada app:translate-sentence

 Enter a sentence to translate:
 > ᚱ ᛝᚱᚪᛗᚹ ᛄᛁᚻᛖᛁᛡᛁ ᛗᚫᚣᚹ ᛠᚪᚫᚾ

 Reverse the translation? (y/n) [n]:
 > y

A WARN[NG|ING] BELIEUE NOTH[NG|ING] FROM
➜  tool git:(reverse) 
```