### PR TITLE
feat: support index skips during vigenere

### DIFF
--- a/tool/app/Actions/Runes/TranslateVigenere.php
+++ b/tool/app/Actions/Runes/TranslateVigenere.php
@@ -13,7 +13,7 @@ class TranslateVigenere
         /* @var array[]|Rune[] $key */
         $letters = '';
         $runicIndex = 0;
-        $letterIndex = 0;
+        $runningRunicIndex = 0;
         $staticRunes = Rune::cases();
         $countOfRunes = count($staticRunes);
         $method = $reversed ? 'toReversedNumericPosition' : 'toNumericPosition';
@@ -22,7 +22,7 @@ class TranslateVigenere
         // Our key is an array of each rune. We need to use index of each key to determine how to resolve the rune.
         // For example - giving "d" we know that is 6
         foreach ($runes as $rune) {
-            $letterIndex++;
+            $runningRunicIndex++;
 
             if ($rune === ' ') {
                 $letters .= ' ';
@@ -37,7 +37,7 @@ class TranslateVigenere
             }
 
             // For some ciphers, we may want to skip shifting at random points.
-            if (in_array($letterIndex, $indexesToSkip)) {
+            if (in_array($runningRunicIndex, $indexesToSkip)) {
                 $letters .= $runeEnum->toSingleLetter();
 
                 continue;

--- a/tool/app/Actions/Runes/TranslateVigenere.php
+++ b/tool/app/Actions/Runes/TranslateVigenere.php
@@ -8,11 +8,12 @@ use App\Enums\Rune;
 
 class TranslateVigenere
 {
-    public static function translate(string $sentence, array $key, bool $reversed = false): string
+    public static function translate(string $sentence, array $key, array $indexesToSkip = [], bool $reversed = false): string
     {
         /* @var array[]|Rune[] $key */
         $letters = '';
         $runicIndex = 0;
+        $letterIndex = 0;
         $staticRunes = Rune::cases();
         $countOfRunes = count($staticRunes);
         $method = $reversed ? 'toReversedNumericPosition' : 'toNumericPosition';
@@ -21,6 +22,8 @@ class TranslateVigenere
         // Our key is an array of each rune. We need to use index of each key to determine how to resolve the rune.
         // For example - giving "d" we know that is 6
         foreach ($runes as $rune) {
+            $letterIndex++;
+
             if ($rune === ' ') {
                 $letters .= ' ';
 
@@ -30,6 +33,13 @@ class TranslateVigenere
             // If we don't recognize rune, just output (ie dots)
             $runeEnum = Rune::tryFrom($rune);
             if (! $runeEnum) {
+                continue;
+            }
+
+            // For some ciphers, we may want to skip shifting at random points.
+            if (in_array($letterIndex, $indexesToSkip)) {
+                $letters .= $runeEnum->toSingleLetter();
+
                 continue;
             }
 

--- a/tool/app/Commands/TranslateVigenere.php
+++ b/tool/app/Commands/TranslateVigenere.php
@@ -16,10 +16,12 @@ class TranslateVigenere extends Command
     {
         $sentence = $this->ask('Enter a sentence to translate');
         $key = $this->ask('Enter the key.');
+        $indexesToSkip = $this->ask('Enter the indexes to skip.');
         $runicKey = GenerateRunesFromEnglish::handle($key);
+        $indexesToSkip = explode(',', $indexesToSkip);
 
-        $translation = TranslateVigenereAction::translate($sentence, $runicKey);
-        $reversedTranslation = TranslateVigenereAction::translate($sentence, $runicKey, true);
+        $translation = TranslateVigenereAction::translate($sentence, $runicKey, $indexesToSkip);
+        $reversedTranslation = TranslateVigenereAction::translate($sentence, $runicKey, $indexesToSkip, true);
 
         $this->output->write('Translation: '.$translation.PHP_EOL);
         $this->output->write('Reversed Translation: '.$reversedTranslation.PHP_EOL);

--- a/tool/tests/Feature/TranslateVigenereTest.php
+++ b/tool/tests/Feature/TranslateVigenereTest.php
@@ -15,6 +15,7 @@ class TranslateVigenereTest extends TestCase
         $this->artisan('app:vigenere')
             ->expectsQuestion('Enter a sentence to translate', $ciphertext)
             ->expectsQuestion('Enter the key.', $key)
+            ->expectsQuestion('Enter the indexes to skip.', '')
             ->assertOk()
             ->expectsOutputToContain($expected);
     }


### PR DESCRIPTION
```
➜  tool git:(vigenere-indexes) ✗ php cicada app:vigenere        

 Enter a sentence to translate:
 > ᚢᛠᛝᛋᛇᚠᚳ ᚱᛇᚢᚷᛈᛠᛠ ᚠᚹᛉᛏᚳᛚᛠ ᚣᛗ ᛠᛇ ᛏᚳᚾᚫ ᛝᛗᛡᛡᛗᛗᚹ ᚫᛈᛞᛝᛡᚱ ᚩᛠ ᛡᛗᛁ ᚠᚠ ᛖᚢᛝ ᛇᚢᚫ ᚣᛈ ᚱᚫ ᛁᛈᚫ ᚳᚫ ᚫᚾᚹ ᛒᛉᛗᛞ ᚱᛡᛁ ᚠᛈᚳ ᛇᛇᚫᚳ ᚱᚦᛈ ᚠᛄᛗᚩ ᛇᚳᚹᛡ ᛒᚫᚹ ᛒᛠᛚᛋ ᚱᚣ ᛄᚫ ᚱ ᛗᚳᚦᛇᚫᛏᚳᛈᚹ ᛗᚷᛇ ᚳ ᛝᛈᚢ ᛇᚳ ᚱᛖᚹ ᛡᛈᛁ ᛒᚣᛒᛉ ᚠᛚᛁᚱ ᚱᛗ ᚳᚷᛒ ᚣᚱ ᚳᚠᚢ ᚦᛈᛡᛄᚹᛏᚠᛠ ᛄᚷᛒ ᚫᚦᚠᚠᛠᛈᚦ ᛈᚠᚪᛉ ᛄᛗᛖᛈᛝᛋᚩᛋᛗ ᚹᛇᛄᛚ ᚹᛉᚢᚦᚫᚹᛗᚦ ᛞᚣᛄᚳ ᛋᛡᛉᚩᛝᚱᛗᛒᚹ ᚱᛗᛁ ᛞᚣᛄᚳ ᛉᚻᚢᚣᛈᛚ ᛄᛝᚣᛗᚠᛄᛈᛇᚢᛡ ᚹᛇᛄ ᛞᚹᛉᚢ ᚪᛚᚪᛋᛗᛡᛇᛉ ᚫᛗ ᛡᛗᛁ ᛈᚣ ᚫᛗᚢᚠ

 Enter the key.:
 > divinity

 Enter the indexes to skip.:
 > 59,95,108,171,205,206,313

Translation: WEL[C|K]OME WEL[C|K]OME PILGRIM TO THE GREAT JOURNEY TOWARD THE END OF ALL TH[NG|ING][S|Z] IT I[S|Z] NOT AN EA[S|Z]Y TRIP BUT FOR THO[S|Z]E WHO FIND THEIR WAY HERE IT I[S|Z] A NE[C|K]E[S|Z][S|Z]ARY ONE A LO[NG|ING] THE WAY YOU WILL FIND AN END TO ALL [S|Z]TRUGGLE AND [S|Z]UFFER[NG|ING] YOUR INNO[C|K]EN[C|K]E YOUR ILLU[S|Z][IA|IO]N[S|Z] YOUR [C|K]ERTAINTY AND YOUR REALITY ULTIMATELY YOU WILL DI[S|Z][C|K]OUER AN END TO [S|Z]ELF
```