### PR TITLE
feat: add alternative "do not share this info" msg

### DIFF
--- a/messages/2013/do-not-share-this-information-2.asc
+++ b/messages/2013/do-not-share-this-information-2.asc
@@ -1,0 +1,65 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+DO NOT SHARE THIS INFORMATION!
+
+Congratulations!  Your testing has finally come to an end.  We hope you have enjoyed
+the "vacation" over the last few weeks.  You will be very busy now should you choose
+to join us.
+
+There are two final steps, although there won't be any hidden codes, or secret messages,
+or physical treasure hunts.  This first of these is only honesty.  We have always been
+honest with you, and we shall continue to be honest with you.  And we expect you to be
+honest with us in return.
+
+You have all wondered who we are, and so we shall now tell you : We are an international
+group.  We have no name.  We have no symbol.  We have no membership rosters.  We do not
+have a public website, and we do not advertise ourselves.  We are a group of individuals
+who have proven ourselves.  Much like you have by completing this recruitment contest.
+And we are drawn together by common beliefs.  A careful reading of the texts used in
+the contest would have revealed some of these beliefs : that tyranny and oppression
+of any kind must end; that censorship is wrong; and that privacy is an inalienable right.
+
+We are not a 'hacker' group.  Nor are we a 'warez' group.  We do not engage in illegal
+activity, nor do our members.  If you are engaged in illegal activity, we ask that you
+cease any and all illegal activities or decline membership at this time.  We will not
+ask questions if you decline; however, if you lie to us we will find out.
+
+You are undoubtedly wondering what it is that we do.  We are much like a "Think Tank" in
+that our primary focus is on researching and developing techniques to aid the ideas we
+advocate : liberty, privacy, security.  You have undoubtedly heard of a few of our past
+projects.  And if you choose to accept membership, we are happy to have you on board to
+help with future projects.
+
+Please answer the next few questions, and send your encrypted responses to
+c1231507051321@gmail.com
+
+* Do you believe that every human being has a right to privacy and anonymity, and is within
+  their rights to use tools which help obtain and maintain privacy : i.e., cash, strong
+  encryption, anonymity software, etc?
+
+* Do you believe that information should be free?
+
+* Do you believe that censorship harms humanity?
+
+
+We look forward to hearing from you.
+
+3301
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1.4.11 (GNU/Linux)
+
+iQIcBAEBAgAGBQJRMuCNAAoJEBgfAeV6NQkPkHgQAJVTAKbfqa9GtKBOOi+zGRF7
+EhyirBRHeFAuj5aY5gWTPKCSdOxKG30Lu0YYJxDaaGuqnYlUuHmTw8OWVozk4GeS
+1shuUqJpDexuUghwCElOyVUi6xtb9Jrn/vy/fXxlowNZx0pKLsuPXWFz+IAQ/whH
+DBxoo79dX8gDls+AkaMWJfRh2oaiWq33C2U8dJOeDglCkc5Tbceb46hsV8mKpBNF
+438mlwXpu+JUfoUvbtnA0gFJpjQVdIWHNY+2oLqOQ5bcictycisaDWbrXgYV4shw
+S5l5hhSF5ZC4JSRphqgnlcZcA5YaSUdyAsqL9O1FnJCHUxshr41bxyz66CZCbe8T
+j3j4jagg+ZIHEOSXaFtd56fH3sxH2kS5lPG6h/mort4Y13u/ktN1YlbHhb8fZ+mn
+LJj+bSdCJznbgSRFumT5w8ibT7mGxgC9fULHwtQncZhk7edofqVqw+ooW8NBU5ma
+DkmPADBTNIEQYEej8z7zoH+N7olGpi2FWn1tEeZzPAmez+UQ010tNvbKUc/jJUqL
+tUNiaO4x9rHjJGvF+5G1KcQjylArp73gnn7FH8yc0f5Fk+bL35b2PVaBU1I0f7Qv
+LM5SfkYxZ5IQbKbAJHb4v15YDUsmLHww372xpTEusf+2J0G1gdLPPH6Rw3Hhtfri
+NezBPwLs+raEcz91KnmR
+=rrq6
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
Saw another "DO NOT SHARE THIS INFORMATION" message with a valid signature different to the one we have.

https://www.reddit.com/r/cicada/comments/1cb3u1f/another_recruitment_message_with_a_different/