### PR TITLE
Handle numerics in Vigenere Bruteforcing

### DIFF
--- a/tool/app/Commands/BruteforceVigenereKey.php
+++ b/tool/app/Commands/BruteforceVigenereKey.php
@@ -24,16 +24,17 @@ class BruteforceVigenereKey extends Command
         $tableData = [];
 
         $this->output->write('Iterating through '.count($words).' wordlists...'.PHP_EOL);
-        $bar = $this->output->createProgressBar(count($words));
-        $bar->start();
 
         foreach ($words as $word) {
+            // If word contains numbers - abandon as it's not a valid key.
+            if (preg_match('/\d/', $word)) {
+                continue;
+            }
+
             $runicKey = GenerateRunesFromEnglish::handle($word);
 
             // We may have a word that doesn't translate to runes.
             if (count($runicKey) === 0) {
-                $bar->advance();
-
                 continue;
             }
 
@@ -45,11 +46,7 @@ class BruteforceVigenereKey extends Command
                 'translation' => $translation,
                 'reversedTranslation' => $reversedTranslation,
             ];
-
-            $bar->advance();
         }
-
-        $bar->finish();
 
         $this->output->write(PHP_EOL);
 

--- a/tool/app/Commands/BruteforceVigenereKey.php
+++ b/tool/app/Commands/BruteforceVigenereKey.php
@@ -24,10 +24,14 @@ class BruteforceVigenereKey extends Command
         $tableData = [];
 
         $this->output->write('Iterating through '.count($words).' wordlists...'.PHP_EOL);
+        $bar = $this->output->createProgressBar(count($words));
+        $bar->start();
 
         foreach ($words as $word) {
             // If word contains numbers - abandon as it's not a valid key.
             if (preg_match('/\d/', $word)) {
+                $bar->advance();
+
                 continue;
             }
 
@@ -35,6 +39,8 @@ class BruteforceVigenereKey extends Command
 
             // We may have a word that doesn't translate to runes.
             if (count($runicKey) === 0) {
+                $bar->advance();
+
                 continue;
             }
 
@@ -46,7 +52,11 @@ class BruteforceVigenereKey extends Command
                 'translation' => $translation,
                 'reversedTranslation' => $reversedTranslation,
             ];
+
+            $bar->advance();
         }
+
+        $bar->finish();
 
         $this->output->write(PHP_EOL);
 

--- a/tool/tests/Feature/BruteforceVigenereTest.php
+++ b/tool/tests/Feature/BruteforceVigenereTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class BruteforceVigenereTest extends TestCase
+{
+    public function test_bruteforce_vigenere(): void
+    {
+        $sentence = 'ᚢᛠᛝᛋᛇᚠᚳ ᚱᛇᚢᚷᛈᛠᛠ ᚠᚹᛉ';
+
+        $this->artisan('app:bruteforce-vigenere')
+            ->expectsQuestion('Enter a sentence to bruteforce', $sentence)
+            ->expectsOutputToContain('divinity')
+            ->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
I did not have test coverage for this command and I when I added the 3301/1033 permutations I broke this as a number does not convert into anything runic. This adds coverage and skips numeric keys.