### PR TITLE
chore: use pr, not pr_target

### DIFF
--- a/.github/workflows/message_verifier.yaml
+++ b/.github/workflows/message_verifier.yaml
@@ -2,7 +2,7 @@ name: Message Verifier
 on:
   push:
     branches: [ master ]
-  pull_request_target:
+  pull_request:
 
 jobs:
   verify:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,7 +2,7 @@ name: PHP CI
 on:
   push:
     branches: [ master ]
-  pull_request_target:
+  pull_request:
 
 jobs:
   php:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -2,7 +2,7 @@ name: Shellcheck
 on:
   push:
     branches: [ master ]
-  pull_request_target:
+  pull_request:
 
 jobs:
   shellcheck:

--- a/.github/workflows/wordlist_verifier.yaml
+++ b/.github/workflows/wordlist_verifier.yaml
@@ -2,7 +2,7 @@ name: Wordlist Verifier
 on:
   push:
     branches: [ master ]
-  pull_request_target:
+  pull_request:
 
 jobs:
   verify:


### PR DESCRIPTION
This was useless as tests ran in context of the parent, which meant none of my changes were validated until after merge.