### PR TITLE
chore: add indexes to skip output to prime cipher

### DIFF
--- a/liber_primus/markdown/73.md
+++ b/liber_primus/markdown/73.md
@@ -37,7 +37,7 @@ d4618dee09a8425893dc7500b
 ```
 ➜ php cicada app:bruteforce-prime-cipher "ᚫᛄ ᛟᛋᚱ ᛗᚣᛚᚩᚻ ᚩᚫ ᚳᚦᚷᚹ ᚹᛚᚫ ᛉᚩᚪᛈ ᛗᛞᛞᚢᚷᚹ ᛚ ᛞᚾᚣᛄ ᚳᚠᛡ ᚫᛏᛈᛇᚪᚦ ᚳᚫ 36367763ab73783c7af284446c59466b4cd653239a311cb7116d4618dee09a8425893dc7500b464fdaf1672d7bef5e891c6e2274568926a49fb4f45132c2a8b4 ᚳᛞ ᚠᚾ ᛡᛖ ᚠᚾᚳᛝ ᚱᚠ ᚫᛁᚱᛞᛖ ᛋᚣᛄᛠᚢᛝᚹ ᛉᚩ ᛗᛠᚹᚠ ᚱᚷᛡ ᛝᚱᛒ ᚫᚾᚢᛋ" --shift=1 202
 Shift provided: 1
-Indexes to Skip: [202]
+Indexes to skip: 202
 
 AN END WITHIN THE DEEP WEB THERE EXI[S|Z]T[S|Z] A PAGE THAT HA[S|Z]HE[S|Z] TO 36367763ab73783c7af284446c59466b4cd653239a311cb7116d4618dee09a8425893dc7500b464fdaf1672d7bef5e891c6e2274568926a49fb4f45132c2a8b4 IT I[S|Z] THE DUTY OF EUERY PILGRIM TO [S|Z]EE[C|K] OUT THI[S|Z] PAGE
 ```

--- a/tool/app/Commands/BruteforcePrimeCipher.php
+++ b/tool/app/Commands/BruteforcePrimeCipher.php
@@ -51,6 +51,7 @@ class BruteforcePrimeCipher extends Command
 
         $plaintext = GeneratePlaintextFromPrimeShiftedCipher::handle($runes, $shift, $indexesToSkip);
         $this->info('Shift provided: '.$shift);
+        $this->info('Indexes to skip: '.implode(', ', $indexesToSkip));
         $this->newLine();
         $this->info($plaintext);
 


### PR DESCRIPTION
This should make it easier to discover which indexes you are skipping, since we output it.