### PR TITLE
fix: infinite recursion in Rune::toReversedLetter()

### DIFF
--- a/tool/app/Enums/Rune.php
+++ b/tool/app/Enums/Rune.php
@@ -56,7 +56,7 @@ enum Rune: string
             self::W => ['NG', 'ING'],
             self::P => ['S', 'Z'],
             self::D => ['C', 'K'],
-            default => $this->toReversedLetter()
+            default => $this->toReversedSingleLetter()
         };
     }
 

--- a/tool/tests/Unit/GematriaPrimusTest.php
+++ b/tool/tests/Unit/GematriaPrimusTest.php
@@ -20,6 +20,16 @@ class GematriaPrimusTest extends TestCase
         $this->assertSame($raw, $rune->toRune());
     }
 
+    public function test_reversed_letters_mirror_the_rune_table(): void
+    {
+        foreach (Rune::cases() as $rune) {
+            $mirrored = Rune::tryFromIndex($rune->toReversedNumericPosition());
+
+            $this->assertSame($mirrored->toLetter(), $rune->toReversedLetter());
+            $this->assertSame($mirrored->toSingleLetter(), $rune->toReversedSingleLetter());
+        }
+    }
+
     public static function dataProvider(): array
     {
         return [


### PR DESCRIPTION
The default arm called toReversedLetter() (itself) instead of toReversedSingleLetter(), so any non-special rune blew the stack. Adds a test asserting the reversed letter mappings mirror the rune table.
